### PR TITLE
Extending test session length

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -25,10 +25,12 @@ class LocustUserBehavior(TaskSet):
         pass_entry = os.getenv("PASS")
         username = self.client.find_element_by_id("login-email")
         pw = self.client.find_element_by_id("login-password")
+        box = self.client.find_element_by_class_name("checkbox")
         username.clear()
         username.send_keys(user_entry)
         pw.clear()
         pw.send_keys(pass_entry)
+        box.click()
         self.client.find_element_by_id("login-submit").click()
 
     def logout(self):

--- a/nuke-from-orbit/docker-image/locust-tasks/tasks.py
+++ b/nuke-from-orbit/docker-image/locust-tasks/tasks.py
@@ -25,10 +25,12 @@ class LocustUserBehavior(TaskSet):
         pass_entry = os.getenv("PASS")
         username = self.client.find_element_by_id("login-email")
         pw = self.client.find_element_by_id("login-password")
+        box = self.client.find_element_by_class_name("checkbox")
         username.clear()
         username.send_keys(user_entry)
         pw.clear()
         pw.send_keys(pass_entry)
+        box.click()
         self.client.find_element_by_id("login-submit").click()
 
     def logout(self):


### PR DESCRIPTION
By default, Looker ends sessions after 30 minutes (or whatever the default session length is set to). Testing may need to extend beyond that timeframe so I've included the "click here to stay logged in" action during login. This should allow for each test browser to stay logged in beyond the standard session length.